### PR TITLE
Remove tags from agent createOnly properties

### DIFF
--- a/aws-datasync-agent/aws-datasync-agent.json
+++ b/aws-datasync-agent/aws-datasync-agent.json
@@ -100,8 +100,7 @@
     "/properties/AgentArn"
   ],
   "createOnlyProperties": [
-    "/properties/ActivationKey",
-    "/properties/Tags"
+    "/properties/ActivationKey"
   ],
   "handlers": {
     "create": {


### PR DESCRIPTION
*Description of changes:*

Somehow, `Tags` snuck back into `createOnly` properties for the agent. This removes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
