### PR TITLE
Require all required properties

### DIFF
--- a/aws-datasync-agent/aws-datasync-agent.json
+++ b/aws-datasync-agent/aws-datasync-agent.json
@@ -92,6 +92,9 @@
     }
   },
   "additionalProperties": false,
+  "required": [
+    "ActivationKey"
+  ],
   "readOnlyProperties": [
     "/properties/AgentArn",
     "/properties/EndpointType"

--- a/aws-datasync-locationfsxwindows/aws-datasync-locationfsxwindows.json
+++ b/aws-datasync-locationfsxwindows/aws-datasync-locationfsxwindows.json
@@ -94,6 +94,7 @@
   "additionalProperties": false,
   "required": [
     "User",
+    "Password",
     "SecurityGroupArns",
     "FsxFilesystemArn"
   ],

--- a/aws-datasync-locationsmb/aws-datasync-locationsmb.json
+++ b/aws-datasync-locationsmb/aws-datasync-locationsmb.json
@@ -117,6 +117,7 @@
   "additionalProperties": false,
   "required": [
     "User",
+    "Password",
     "Subdirectory",
     "ServerHostname",
     "AgentArns"


### PR DESCRIPTION
*Description of changes:*
These three properties are required by our API according to our docs but were omitted by the resource schemas.

Enforcing required properties means that users get a cloudformation validation error instead of a datasync validation error. Both result in CREATE_FAILED stacks, but since cloudformation validation happens first, no call is made to datasync and the validation error is thrown sooner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.