### PR TITLE
Change BytesPerSecond to use int64 format to allow larger values

### DIFF
--- a/aws-datasync-task/aws-datasync-task.json
+++ b/aws-datasync-task/aws-datasync-task.json
@@ -78,6 +78,7 @@
         "BytesPerSecond": {
           "description": "A value that limits the bandwidth used by AWS DataSync.",
           "type": "integer",
+          "format": "int64",
           "minimum": -1
         },
         "Gid": {

--- a/aws-datasync-task/src/main/java/software/amazon/datasync/task/Translator.java
+++ b/aws-datasync-task/src/main/java/software/amazon/datasync/task/Translator.java
@@ -90,10 +90,9 @@ public class Translator {
             final software.amazon.awssdk.services.datasync.model.Options options) {
         if (options == null)
             return software.amazon.datasync.task.Options.builder().build();
-        Integer bytesPerSecond = options.bytesPerSecond() != null ? options.bytesPerSecond().intValue() : null;
         return software.amazon.datasync.task.Options.builder()
                 .atime(options.atimeAsString())
-                .bytesPerSecond(bytesPerSecond)
+                .bytesPerSecond(options.bytesPerSecond())
                 .gid(options.gidAsString())
                 .logLevel(options.logLevelAsString())
                 .mtime(options.mtimeAsString())
@@ -112,11 +111,9 @@ public class Translator {
             final software.amazon.datasync.task.Options options) {
         if (options == null)
             return software.amazon.awssdk.services.datasync.model.Options.builder().build();
-
-        Long bytesPerSecond = options.getBytesPerSecond() != null ? options.getBytesPerSecond().longValue() : null;
         return software.amazon.awssdk.services.datasync.model.Options.builder()
                 .atime(options.getAtime())
-                .bytesPerSecond(bytesPerSecond)
+                .bytesPerSecond(options.getBytesPerSecond())
                 .gid(options.getGid())
                 .logLevel(options.getLogLevel())
                 .mtime(options.getMtime())


### PR DESCRIPTION
*Description of changes:*
BytesPerSecond should be long format, but a json `int` is a 32 bit signed int  (max value 2,147,483,647). A task created with BytesPerSecond > 2147483647 would fail (I verified this manually).

cloudformation-cli recently added support for specifying a long by using the `format: int64` schema property. With this change, resource handlers represent these properties using java Long rather than Integer, and valid large inputs are not rejected.

I reviewed all our agent/location/task APIs; this is the only API property that needs this change.

*Testing:*
- successfully created stack with `"BytesPerSecond": 2147483648`
- successfully created stack with no BytesPerSecond specified, to ensure default value (-1) is correctly set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
