### PR TITLE
Enforce additional properties are not allowed in schema object definitions

### DIFF
--- a/aws-datasync-agent/aws-datasync-agent.json
+++ b/aws-datasync-agent/aws-datasync-agent.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-locationefs/aws-datasync-locationefs.json
+++ b/aws-datasync-locationefs/aws-datasync-locationefs.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "Ec2Config": {
+      "additionalProperties": false,
       "description": "The subnet and security group that DataSync uses to access target EFS file system.",
       "type": "object",
       "properties": {
@@ -31,6 +32,7 @@
       ]
     },
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-locationfsxwindows/aws-datasync-locationfsxwindows.json
+++ b/aws-datasync-locationfsxwindows/aws-datasync-locationfsxwindows.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-locationnfs/aws-datasync-locationnfs.json
+++ b/aws-datasync-locationnfs/aws-datasync-locationnfs.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "MountOptions": {
+      "additionalProperties": false,
       "description": "The NFS mount options that DataSync can use to mount your NFS share.",
       "type": "object",
       "properties": {
@@ -20,6 +21,7 @@
       }
     },
     "OnPremConfig": {
+      "additionalProperties": false,
       "description": "Contains a list of Amazon Resource Names (ARNs) of agents that are used to connect an NFS server.",
       "type": "object",
       "properties": {
@@ -40,6 +42,7 @@
       ]
     },
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-locationobjectstorage/aws-datasync-locationobjectstorage.json
+++ b/aws-datasync-locationobjectstorage/aws-datasync-locationobjectstorage.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-locations3/aws-datasync-locations3.json
+++ b/aws-datasync-locations3/aws-datasync-locations3.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "S3Config": {
+      "additionalProperties": false,
       "description": "The Amazon Resource Name (ARN) of the AWS IAM role that is used to access an Amazon S3 bucket.",
       "type": "object",
       "properties": {
@@ -19,6 +20,7 @@
       ]
     },
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-locationsmb/aws-datasync-locationsmb.json
+++ b/aws-datasync-locationsmb/aws-datasync-locationsmb.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "MountOptions": {
+      "additionalProperties": false,
       "description": "The mount options used by DataSync to access the SMB server.",
       "type": "object",
       "properties": {
@@ -19,6 +20,7 @@
       }
     },
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {

--- a/aws-datasync-task/aws-datasync-task.json
+++ b/aws-datasync-task/aws-datasync-task.json
@@ -4,6 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datasync.git",
   "definitions": {
     "FilterRule": {
+      "additionalProperties": false,
       "description": "Specifies which files folders and objects to include or exclude when transferring files from source to destination.",
       "type": "object",
       "properties": {
@@ -25,6 +26,7 @@
       }
     },
     "Tag": {
+      "additionalProperties": false,
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "properties": {
@@ -49,6 +51,7 @@
       ]
     },
     "TaskSchedule": {
+      "additionalProperties": false,
       "description": "Specifies the schedule you want your task to use for repeated executions.",
       "type": "object",
       "properties": {
@@ -64,6 +67,7 @@
       ]
     },
     "Options": {
+      "additionalProperties": false,
       "description": "Represents the options that are available to control the behavior of a StartTaskExecution operation.",
       "type": "object",
       "properties": {


### PR DESCRIPTION
*Description of changes:*
CloudFormation added a new schema validation rule that requires property definitions to specify "additionalProperties": false, which will validate that no unexpected subproperties are included.

For more info, see: https://github.com/aws-cloudformation/cloudformation-cli/pull/642/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.